### PR TITLE
Loosen dependency version requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,15 @@
 [tool.poetry]
 name = "zygoat-django"
-version = "0.3.0"
+version = "0.4.0"
 description = ""
 authors = ["Mark Rawls <markrawls96@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.6"
 importlib-metadata = "^1.7.0"
-django = "^3.1.1"
-django-environ = "^0.4.5"
-djangorestframework = "^3.11.1"
+django = ">=2"
+django-environ = "^0.4.4"
+djangorestframework = "^3.9.1"
 djangorestframework-camel-case = "^1.2.0"
 django-redis = "^4.12.1"
 


### PR DESCRIPTION
With the new pip dependency resolver, we need to accept a wider range of versions for these dependencies if we are going to use zygoat-django in the estate-planning project.